### PR TITLE
BUGFIX: If user sets empty tag for Preset Pie it crashes SC

### DIFF
--- a/shortcut_composer/templates/pie_menu_utils/pie_style.py
+++ b/shortcut_composer/templates/pie_menu_utils/pie_style.py
@@ -78,7 +78,8 @@ class PieStyle:
             * self.icon_radius_scale
             * Config.PIE_ICON_GLOBAL_SCALE.read()
         )
-        max_icon_size = round(self.pie_radius * math.pi / self._icons_amount)
+        max_icon_size = round(self.pie_radius * math.pi /
+            (self._icons_amount if self._icons_amount > 0 else 1))
         return min(icon_radius, max_icon_size)
 
     def _pick_deadzone_radius(self) -> float:


### PR DESCRIPTION
Removed division by 0 case.

Probably fixes:
https://krita-artists.org/t/shortcut-composer-v1-1-0-plugin-for-pie-menus-multiple-key-assignment-mouse-trackers-and-more/55314/86?u=sirpigeonz