### PR TITLE
Tools to control blending of Color Sampler Tool

### DIFF
--- a/shortcut_composer/actions.action
+++ b/shortcut_composer/actions.action
@@ -101,6 +101,10 @@
         <activationFlags>1</activationFlags>
         </Action>
 
+        <Action name="Pick Color Sampler Blend">
+        <activationFlags>1</activationFlags>
+        </Action>
+
     </Actions>
     <Actions category="Scripts">
         <text>Shortcut Composer: Utilities</text>

--- a/shortcut_composer/actions.py
+++ b/shortcut_composer/actions.py
@@ -244,6 +244,12 @@ def create_actions() -> List[ComplexAction]: return [
         active_color=QColor(110, 160, 235),
     ),
 
+    templates.PieMenu(
+        name="Pick Color Sampler Blend",
+        controller=controllers.ColorSamplerBlendController(),
+        values=[100, 95, 90, 80, 70, 60, 50, 40, 30, 20, 10, 5],
+    ),
+
     # .......................................
     # Insert your actions implementation here
     # .......................................

--- a/shortcut_composer/api_krita/actions/__init__.py
+++ b/shortcut_composer/api_krita/actions/__init__.py
@@ -4,4 +4,7 @@
 from .transform_actions import TransformModeActions, TransformModeFinder
 from .color_sampler_actions import ColorSamplerOptionsFinder
 
-__all__ = ["TransformModeActions", "TransformModeFinder", "ColorSamplerOptionsFinder"]
+__all__ = ["TransformModeActions",
+           "TransformModeFinder",
+           "ColorSamplerOptionsFinder"
+           ]

--- a/shortcut_composer/api_krita/actions/__init__.py
+++ b/shortcut_composer/api_krita/actions/__init__.py
@@ -2,5 +2,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from .transform_actions import TransformModeActions, TransformModeFinder
+from .color_sampler_actions import ColorSamplerOptionsFinder
 
-__all__ = ["TransformModeActions", "TransformModeFinder"]
+__all__ = ["TransformModeActions", "TransformModeFinder", "ColorSamplerOptionsFinder"]

--- a/shortcut_composer/api_krita/actions/color_sampler_actions.py
+++ b/shortcut_composer/api_krita/actions/color_sampler_actions.py
@@ -60,7 +60,7 @@ class ColorSamplerOptionsFinder:
         """Fetch widget with Color Sampler tool options."""
         for qobj in Krita.get_active_qwindow().findChildren(QWidget):
             if qobj.objectName() == (
-                Tool.COLOR_SAMPLER.value + " option widget"):
+                    Tool.COLOR_SAMPLER.value + " option widget"):
                 return qobj  # type: ignore
         raise RuntimeError("Color Sampler options not found.")
 
@@ -71,5 +71,4 @@ class ColorSamplerOptionsFinder:
             raise RuntimeError("Could not ifnd the Blend SpinBox.")
         for qobj in blend_spinbox_list:
             if qobj.objectName() == "blend":
-                return qobj # type: ignore
-
+                return qobj  # type: ignore

--- a/shortcut_composer/api_krita/actions/color_sampler_actions.py
+++ b/shortcut_composer/api_krita/actions/color_sampler_actions.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2022 Wojciech Trybus <wojtryb@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from PyQt5.QtWidgets import (
+    QWidget,
+    QSpinBox,
+)
+
+from ..enums import Tool
+from ..core_api import KritaInstance
+Krita = KritaInstance()
+
+
+class ColorSamplerOptionsFinder:
+    """
+    Helper class for finding components related to Color Sampler Tool.
+
+    Stores elements of krita needed to control Color Sampler Tool:
+    - Widget Color Sampler tool options
+    - Blend property of Color Sampler
+
+    As the widget do not exist during plugin intialization phase,
+    fetching the elements needs to happen at runtime.
+    """
+
+    def __init__(self) -> None:
+        self._initialized = False
+
+        self._color_sampler_options: QWidget
+        self._blend_spinbox: QSpinBox
+
+    def ensure_initialized(self) -> None:
+        """Fetch widget and blend spinbox if not done already."""
+        if not self._initialized:
+            last_tool = Krita.active_tool
+            Krita.active_tool = Tool.COLOR_SAMPLER
+            self._color_sampler_options = self._fetch_color_sampler_options()
+            self._blend_spinbox = self._fetch_blend_spinbox()
+            self._initialized = True
+            Krita.active_tool = last_tool
+
+    def set_blend(self, blend: int) -> None:
+        """Set Color Sampler Blend percentage."""
+        self.ensure_initialized()
+
+        last_tool = Krita.active_tool
+        Krita.active_tool = Tool.COLOR_SAMPLER
+
+        blend = sorted((1, blend, 100))[1]
+        self._blend_spinbox.setValue(blend)
+
+        Krita.active_tool = last_tool
+
+    def get_blend(self) -> int:
+        """Get Color Sampler Blend percentage."""
+        self.ensure_initialized()
+        return self._blend_spinbox.value()
+
+    def _fetch_color_sampler_options(self) -> QWidget:
+        """Fetch widget with Color Sampler tool options."""
+        for qobj in Krita.get_active_qwindow().findChildren(QWidget):
+            if qobj.objectName() == (
+                Tool.COLOR_SAMPLER.value + " option widget"):
+                return qobj  # type: ignore
+        raise RuntimeError("Color Sampler options not found.")
+
+    def _fetch_blend_spinbox(self) -> QSpinBox:
+        """Fetch Color Sampler tool Blend property SpinBox widget."""
+        blend_spinbox_list = self._color_sampler_options.findChildren(QSpinBox)
+        if not blend_spinbox_list:
+            raise RuntimeError("Could not ifnd the Blend SpinBox.")
+        for qobj in blend_spinbox_list:
+            if qobj.objectName() == "blend":
+                return qobj # type: ignore
+

--- a/shortcut_composer/core_components/controllers/__init__.py
+++ b/shortcut_composer/core_components/controllers/__init__.py
@@ -20,6 +20,7 @@ Available controllers:
     - `CanvasZoomController`
     - `ToggleController`
     - `CreateLayerWithBlendingController`
+    - `ColorSamplerBlendController`
 """
 
 from .document_controllers import (
@@ -45,6 +46,7 @@ from .node_controllers import (
 )
 from .core_controllers import (
     TransformModeController,
+    ColorSamplerBlendController,
     ToggleController,
     ToolController,
     UndoController,
@@ -53,6 +55,7 @@ from .core_controllers import (
 __all__ = [
     "LayerBlendingModeController",
     "TransformModeController",
+    "ColorSamplerBlendController",
     "LayerVisibilityController",
     "CanvasRotationController",
     "BlendingModeController",

--- a/shortcut_composer/core_components/controllers/core_controllers.py
+++ b/shortcut_composer/core_components/controllers/core_controllers.py
@@ -75,15 +75,15 @@ class ColorSamplerBlendController(Controller):
 
     def __init__(self) -> None:
         self.blend_spinbox_finder = ColorSamplerOptionsFinder()
-    
+
     def get_value(self) -> int:
         """Get current blend percentage."""
         return self.blend_spinbox_finder.get_blend()
-    
+
     def set_value(self, blend: int) -> None:
         """Set a passed blend percentage."""
         self.blend_spinbox_finder.set_blend(blend)
-    
+
     def get_label(self, value: int) -> Text:
         return Text(f"{value}%", Colorizer.percentage(value))
 

--- a/shortcut_composer/core_components/controllers/core_controllers.py
+++ b/shortcut_composer/core_components/controllers/core_controllers.py
@@ -8,7 +8,8 @@ from PyQt5.QtGui import QIcon
 
 from api_krita import Krita
 from api_krita.enums import Tool, Toggle, TransformMode
-from api_krita.actions import TransformModeFinder
+from api_krita.pyqt import Text, Colorizer
+from api_krita.actions import TransformModeFinder, ColorSamplerOptionsFinder
 from ..controller_base import Controller
 
 
@@ -63,6 +64,28 @@ class TransformModeController(Controller):
 
     def get_label(self, value: Tool) -> QIcon:
         return value.icon
+
+
+class ColorSamplerBlendController(Controller):
+    """
+    Gives access to Blend option in Color Sampler tool.
+    """
+
+    default_value: int = 100
+
+    def __init__(self) -> None:
+        self.blend_spinbox_finder = ColorSamplerOptionsFinder()
+    
+    def get_value(self) -> int:
+        """Get current blend percentage."""
+        return self.blend_spinbox_finder.get_blend()
+    
+    def set_value(self, blend: int) -> None:
+        """Set a passed blend percentage."""
+        self.blend_spinbox_finder.set_blend(blend)
+    
+    def get_label(self, value: int) -> Text:
+        return Text(f"{value}%", Colorizer.percentage(value))
 
 
 @dataclass

--- a/shortcut_composer/core_components/controllers/node_controllers.py
+++ b/shortcut_composer/core_components/controllers/node_controllers.py
@@ -18,20 +18,20 @@ class NodeBasedController(Controller):
 
 class LayerOpacityController(NodeBasedController):
     """
-    Gives access to active layers' `blending mode`.
+    Gives access to active layers' `opacity` in %.
 
-    - Operates on `BlendingMode`
-    - Defaults to `BlendingMode.NORMAL`
+    - Operates on `integer` in range `0 to 100`
+    - Defaults to `100`
     """
 
     default_value: int = 100
 
     def get_value(self) -> int:
-        """Get currently active blending mode."""
+        """Get current layer opacity."""
         return self.active_node.opacity
 
     def set_value(self, opacity: int) -> None:
-        """Set a passed blending mode."""
+        """Set passed layer opacity."""
         if self.active_node.opacity != opacity:
             self.active_node.opacity = opacity
             self.active_document.refresh()
@@ -42,20 +42,20 @@ class LayerOpacityController(NodeBasedController):
 
 class LayerBlendingModeController(NodeBasedController):
     """
-    Gives access to active layers' `opacity` in %.
+    Gives access to active layers' `blending mode`.
 
-    - Operates on `integer` in range `0 to 100`
-    - Defaults to `100`
+    - Operates on `BlendingMode`
+    - Defaults to `BlendingMode.NORMAL`
     """
 
     default_value = BlendingMode.NORMAL
 
     def get_value(self) -> BlendingMode:
-        """Get current brush opacity."""
+        """Get currently active blending mode."""
         return self.active_node.blending_mode
 
     def set_value(self, blending_mode: BlendingMode) -> None:
-        """Set passed brush opacity."""
+        """Set a passed blending mode."""
         if self.active_node.blending_mode != blending_mode:
             self.active_node.blending_mode = blending_mode
             self.active_document.refresh()
@@ -66,7 +66,7 @@ class LayerBlendingModeController(NodeBasedController):
 
 class LayerVisibilityController(NodeBasedController):
     """
-    Gives access to active layers' `visibility`.
+    Gives access to active layers's `visibility`.
 
     - Operates on `bool`
     - Defaults to `True`
@@ -75,11 +75,11 @@ class LayerVisibilityController(NodeBasedController):
     default_value: bool = True
 
     def get_value(self) -> bool:
-        """Get current brush opacity."""
+        """Get active layers's `visibility`."""
         return self.active_node.visible
 
     def set_value(self, visibility: bool) -> None:
-        """Set passed brush opacity."""
+        """Set active layers's `visibility`."""
         if self.active_node.visible != visibility:
             self.active_node.visible = visibility
             self.active_document.refresh()


### PR DESCRIPTION
- Color Sampler Options Finder class added for modifying `Blend` property in Color Sampler
- New `Controller` to control `Blend`
- New Pie Menu to pick percentages for `Blend`
- Small cleanup in node_controllers.py doc-strings