### PR TITLE
Fix crash when configs are invalid

### DIFF
--- a/shortcut_composer/composer_utils/config.py
+++ b/shortcut_composer/composer_utils/config.py
@@ -78,11 +78,16 @@ class Config(Enum):
 
     def read(self) -> Any:
         """Read current value from krita config file."""
-        return type(self.default)(Krita.read_setting(
+        setting = Krita.read_setting(
             group="ShortcutComposer",
             name=self.value,
             default=str(self.default),
-        ))
+        )
+        try:
+            return type(self.default)(setting)
+        except ValueError:
+            print(f"Can't parse {setting} to {type(self.default)}")
+            return self.default
 
     def write(self, value: Any) -> None:
         """Write given value to krita config file."""

--- a/shortcut_composer/composer_utils/utils/action_values.py
+++ b/shortcut_composer/composer_utils/utils/action_values.py
@@ -21,7 +21,7 @@ class ActionValues(QWidget):
     def __init__(self, allowed_values: Set[str], config: Config) -> None:
         super().__init__()
         layout = QHBoxLayout()
-        self.allowed_values = set(allowed_values)
+        self.allowed_values = allowed_values
         self.config = config
 
         self.available_list = ValueList(movable=False, parent=self)
@@ -84,7 +84,9 @@ class ActionValues(QWidget):
         current_list = current.split("\t")
         if current_list == ['']:
             current_list = []
-        self.current_list.addItems(current_list)
+        for item in current_list:
+            if item in self.allowed_values:
+                self.current_list.addItem(item)
 
         self.available_list.clear()
         allowed_items = sorted(self.allowed_values - set(current_list))

--- a/shortcut_composer/data_components/writable_values.py
+++ b/shortcut_composer/data_components/writable_values.py
@@ -62,4 +62,7 @@ class EnumConfigValues(list):
         if value_string == '':
             return
         values_list = value_string.split("\t")
-        self.extend([enum_type[value] for value in values_list])
+        try:
+            self.extend([enum_type[value] for value in values_list])
+        except KeyError:
+            print(f"{values_list} not in {enum_type}")


### PR DESCRIPTION
When reading from .kritarc, there was a possible crash if the configs were not in the correct format (edited by the user manually, or by using a plugin development version with different save format).