### PR TITLE
Deploy v1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The plugin adds new shortcuts of the following types:
 
 [![PIE MENUS - introducing Shortcut Composer](http://img.youtube.com/vi/Tkf2-U0OyG4/0.jpg)](https://www.youtube.com/watch?v=Tkf2-U0OyG4 "PIE MENUS - introducing Shortcut Composer")
 
-
+- [hotfix **1.2.2**] - Fixed MultipleAssignment actions sharing one configuration window.
 - [hotfix **1.2.1**] - Fixed pie menus in edit mode hiding when clicked outside on the canvas.
 
 
@@ -34,7 +34,7 @@ The plugin adds new shortcuts of the following types:
 - Make `input_adapter` package independent from the rest of the plugin to improve re-usability.
 - Fix crash when picking a deleted preset with PieMenu.
 
-Check out historic [changelogs](https://github.com/wojtryb/Shortcut-Composer/wiki/Change-log).
+Check out historic [changelogs](https://github.com/wojtryb/Shortcut-Composer/releases).
 
 ## Plugin release video:
 

--- a/shortcut_composer/INFO.py
+++ b/shortcut_composer/INFO.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: © 2022-2023 Wojciech Trybus <wojtryb@gmail.com>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 __author__ = "Wojciech Trybus"
 __license__ = "GPL-3.0-or-later"

--- a/shortcut_composer/core_components/instruction_base.py
+++ b/shortcut_composer/core_components/instruction_base.py
@@ -27,8 +27,12 @@ class InstructionHolder:
     respective method in every stored Instruction.
     """
 
-    def __init__(self, instructions: List[Instruction] = []) -> None:
+    def __init__(self, instructions: List[Instruction]) -> None:
         self._instructions = instructions
+
+    def append(self, instruction: Instruction):
+        """Add new instruction to the list on runtime."""
+        self._instructions.append(instruction)
 
     def _template(self, method_name: str) -> None:
         """Perform method `method_name` of each held instruction."""

--- a/shortcut_composer/manual.html
+++ b/shortcut_composer/manual.html
@@ -30,6 +30,7 @@
     </ul>
     <h2 id="what-s-new-in-1-2-">What&#39;s new in <strong>1.2</strong></h2>
     <ul>
+        <li>[hotfix **1.2.2**] - Fixed MultipleAssignment actions sharing one configuration window.</li>
         <li>[hotfix **1.2.1**] - Fixed pie menus in edit mode hiding when clicked outside on the canvas.</li>
     </ul>
     <h3 id="added">Added</h3>
@@ -63,7 +64,7 @@
         </li>
         <li>Fix crash when picking a deleted preset with PieMenu.</li>
     </ul>
-    <p>Check out historic <a href="https://github.com/wojtryb/Shortcut-Composer/wiki/Change-log">changelogs</a>.</p>
+    <p>Check out historic <a href="https://github.com/wojtryb/Shortcut-Composer/releases">changelogs</a>.</p>
     <h2 id="requirements">Requirements</h2>
     <ul>
         <li>Version of krita on plugin release: <strong>5.1.5</strong></li>

--- a/shortcut_composer/templates/multiple_assignment.py
+++ b/shortcut_composer/templates/multiple_assignment.py
@@ -66,7 +66,7 @@ class MultipleAssignment(RawInstructions, Generic[T]):
         controller: Controller[T],
         values: List[T],
         default_value: Optional[T] = None,
-        instructions: List[Instruction] = [],
+        instructions: Optional[List[Instruction]] = None,
         short_vs_long_press_time: Optional[float] = None
     ) -> None:
         super().__init__(name, instructions, short_vs_long_press_time)
@@ -75,11 +75,14 @@ class MultipleAssignment(RawInstructions, Generic[T]):
         self._default_value = self._read_default_value(default_value)
 
         self.config = Field(
-            config_group=f"ShortcutComposer: {name}",
+            config_group=f"ShortcutComposer: {self.name}",
             name="Values",
             default=values)
 
-        self._settings = SettingsHandler(name, self.config, instructions)
+        self._settings = SettingsHandler(
+            self.name,
+            self.config,
+            self._instructions)
         self._values_to_cycle = self.config.read()
 
         def reset() -> None:

--- a/shortcut_composer/templates/multiple_assignment_utils/settings_handler.py
+++ b/shortcut_composer/templates/multiple_assignment_utils/settings_handler.py
@@ -1,14 +1,13 @@
 # SPDX-FileCopyrightText: © 2022-2023 Wojciech Trybus <wojtryb@gmail.com>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import List
 from enum import Enum
 
 from PyQt5.QtGui import QColor
 
 from api_krita import Krita
 from api_krita.pyqt import RoundButton, Timer
-from core_components import Instruction
+from core_components import Instruction, InstructionHolder
 from config_system import Field
 from .action_values_window import ActionValuesWindow
 
@@ -29,7 +28,7 @@ class SettingsHandler:
         self,
         name: str,
         config: Field[list],
-        instructions: List[Instruction],
+        instructions: InstructionHolder,
     ) -> None:
         to_cycle = config.read()
         if not to_cycle or not isinstance(to_cycle[0], Enum):

--- a/shortcut_composer/templates/pie_menu.py
+++ b/shortcut_composer/templates/pie_menu.py
@@ -69,7 +69,7 @@ class PieMenu(RawInstructions, Generic[T]):
         name: str,
         controller: Controller[T],
         values: List[T],
-        instructions: List[Instruction] = [],
+        instructions: Optional[List[Instruction]] = None,
         pie_radius_scale: float = 1.0,
         icon_radius_scale: float = 1.0,
         background_color: Optional[QColor] = None,

--- a/shortcut_composer/templates/raw_instructions.py
+++ b/shortcut_composer/templates/raw_instructions.py
@@ -42,12 +42,13 @@ class RawInstructions(ComplexActionInterface):
     def __init__(
         self,
         name: str,
-        instructions: List[Instruction] = [],
+        instructions: Optional[List[Instruction]] = None,
         short_vs_long_press_time: Optional[float] = None
     ) -> None:
         self.name = name
         self.short_vs_long_press_time = _read_time(short_vs_long_press_time)
-        self._instructions = InstructionHolder(instructions)
+        self._instructions = InstructionHolder(
+            instructions if instructions is not None else [])
 
     def on_key_press(self) -> None:
         """Run instructions meant for key press event."""

--- a/shortcut_composer/templates/temporary_key.py
+++ b/shortcut_composer/templates/temporary_key.py
@@ -62,7 +62,7 @@ class TemporaryKey(RawInstructions, Generic[T]):
         controller: Controller[T],
         high_value: T,
         low_value: Optional[T] = None,
-        instructions: List[Instruction] = [],
+        instructions: Optional[List[Instruction]] = None,
         short_vs_long_press_time: Optional[float] = None
     ) -> None:
         super().__init__(name, instructions, short_vs_long_press_time)


### PR DESCRIPTION
### Fixed
- Fixed `MultipleAssignment` actions sharing one configuration window.

Note: this bug only occured when creating duplicates of `MultipleAssignment` actions. If you were using the plugin as it is, without creating your own actions, updating to 1.2.2 is not needed.