### PR TITLE
Deploy 1.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Shortcut composer **v1.4.1**
+# Shortcut composer **v1.4.2**
 
 [![python](https://img.shields.io/badge/Python-3.8-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
 [![Code style: black](https://img.shields.io/badge/code%20style-autopep8-333333.svg)](https://pypi.org/project/autopep8/)

--- a/shortcut_composer/INFO.py
+++ b/shortcut_composer/INFO.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: © 2022-2023 Wojciech Trybus <wojtryb@gmail.com>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "1.4.2.dev"
+__version__ = "1.4.2"
 __author__ = "Wojciech Trybus"
 __license__ = "GPL-3.0-or-later"

--- a/shortcut_composer/INFO.py
+++ b/shortcut_composer/INFO.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: © 2022-2023 Wojciech Trybus <wojtryb@gmail.com>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "1.4.1"
+__version__ = "1.4.2.dev"
 __author__ = "Wojciech Trybus"
 __license__ = "GPL-3.0-or-later"

--- a/shortcut_composer/api_krita/enums/blending_mode.py
+++ b/shortcut_composer/api_krita/enums/blending_mode.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: © 2022-2023 Wojciech Trybus <wojtryb@gmail.com>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Optional
 from .helpers import EnumGroup, Group
 
 
@@ -13,75 +12,71 @@ class BlendingMode(EnumGroup):
     """
 
     _arithmetic = Group("Arithmetic")
-    ADD = "add", "Addition"
+    ADD = "add"
     DIVIDE = "divide"
     INVERSE_SUBTRACT = "inverse_subtract"
     MULTIPLY = "multiply"
     SUBTRACT = "subtract"
 
     _binary = Group("Binary")
-    AND = "and", "AND"
-    CONVERSE = "converse", "CONVERSE"
-    IMPLICATION = "implication", "IMPLICATION"
-    NAND = "nand", "NAND"
-    NOR = "nor", "NOR"
-    NOT_CONVERSE = "not_converse", "NOT_CONVERSE"
-    NOT_IMPLICATION = "not_implication", "NOT_IMPLICATION"
-    OR = "or", "OR"
-    XNOR = "xnor", "XNOR"
-    XOR = "xor", "XOR"
+    AND = "and"
+    CONVERSE = "converse"
+    IMPLICATION = "implication"
+    NAND = "nand"
+    NOR = "nor"
+    NOT_CONVERSE = "not_converse"
+    NOT_IMPLICATION = "not_implication"
+    OR = "or"
+    XNOR = "xnor"
+    XOR = "xor"
 
     _darken = Group("Darken")
     BURN = "burn"
     DARKEN = "darken"
     DARKER_COLOR = "darker color"
     EASY_BURN = "easy burn"
-    FOG_DARKEN_IFS_ILLUSIONS = (
-        "fog_darken_ifs_illusions",
-        "Fog Darken (IFS Illusions)")
+    FOG_DARKEN_IFS_ILLUSIONS = "fog_darken_ifs_illusions"
     GAMMA_DARK = "gamma_dark"
     LINEAR_BURN = "linear_burn"
-    SHADE_IFS_ILLUSIONS = (
-        "shade_ifs_illusions"
-        "Shade (IFS Illusions)")
+    SHADE_IFS_ILLUSIONS = "shade_ifs_illusions"
 
     _hsi = Group("HSI")
-    COLOR_HSI = "color_hsi", "Color HSI"
-    DEC_INTENSITY = "dec_intensity", "Decrease Intensity"
-    DEC_SATURATION_HSI = "dec_saturation_hsi", "Decrease Saturation HSI"
-    HUE_HSI = "hue_hsi", "Hue HSI"
-    INC_INTENSITY = "inc_intensity", "Increase Intensity"
-    INC_SATURATION_HSI = "inc_saturation_hsi", "Increase Saturation HSI"
+    COLOR_HSI = "color_hsi"
+    DEC_INTENSITY = "dec_intensity"
+    DEC_SATURATION_HSI = "dec_saturation_hsi"
+    HUE_HSI = "hue_hsi"
+    INC_INTENSITY = "inc_intensity"
+    INC_SATURATION_HSI = "inc_saturation_hsi"
     INTENSITY = "intensity"
-    SATURATION_HSI = "saturation_hsi", "Saturation HSI"
+    SATURATION_HSI = "saturation_hsi"
 
     _hsl = Group("HSL")
-    COLOR_HSL = "color_hsl", "Color HSL"
-    DEC_LIGHTNESS = "dec_lightness", "Decrease Lightness"
-    DEC_SATURATION_HSL = "dec_saturation_hsl", "Decrease Saturation HSL"
-    HUE_HSL = "hue_hsl", "Hue HSL"
-    INC_LIGHTNESS = "inc_lightness", "Increase Lightness"
-    INC_SATURATION_HSL = "inc_saturation_hsl", "Increase Saturation HSL"
+    COLOR_HSL = "color_hsl"
+    DEC_LIGHTNESS = "dec_lightness"
+    DEC_SATURATION_HSL = "dec_saturation_hsl"
+    HUE_HSL = "hue_hsl"
+    INC_LIGHTNESS = "inc_lightness"
+    INC_SATURATION_HSL = "inc_saturation_hsl"
     LIGHTNESS = "lightness"
-    SATURATION_HSL = "saturation_hsl", "Saturation HSL"
+    SATURATION_HSL = "saturation_hsl"
 
     _hsv = Group("HSV")
-    COLOR_HSV = "color_hsv", "Color HSV"
-    DEC_SATURATION_HSV = "dec_saturation_hsv", "Decrease Saturation HSV"
-    DEC_VALUE = "dec_value", "Decrease Value"
-    HUE_HSV = "hue_hsv", "Hue HSV"
-    INC_SATURATION_HSV = "inc_saturation_hsv", "Increase Saturation HSV"
-    INC_VALUE = "inc_value", "Increase Value"
-    SATURATION_HSV = "saturation_hsv", "Saturation HSV"
+    COLOR_HSV = "color_hsv"
+    DEC_SATURATION_HSV = "dec_saturation_hsv"
+    DEC_VALUE = "dec_value"
+    HUE_HSV = "hue_hsv"
+    INC_SATURATION_HSV = "inc_saturation_hsv"
+    INC_VALUE = "inc_value"
+    SATURATION_HSV = "saturation_hsv"
     VALUE = "value"
 
     _hsy = Group("HSY")
     COLOR = "color"
-    DEC_LUMINOSITY = "dec_luminosity", "Decrease Luminosity"
-    DEC_SATURATION = "dec_saturation", "Decrease Saturation"
+    DEC_LUMINOSITY = "dec_luminosity"
+    DEC_SATURATION = "dec_saturation"
     HUE = "hue"
-    INC_LUMINOSITY = "inc_luminosity", "Increase Luminosity"
-    INC_SATURATION = "inc_saturation", "Increase Saturation"
+    INC_LUMINOSITY = "inc_luminosity"
+    INC_SATURATION = "inc_saturation"
     LUMINIZE = "luminize"
     SATURATION = "saturation"
 
@@ -89,9 +84,7 @@ class BlendingMode(EnumGroup):
     DODGE = "dodge"
     EASY_DODGE = "easy dodge"
     FLAT_LIGHT = "flat_light"
-    FOG_LIGHTEN_IFS_ILLUSIONS = (
-        "fog_lighten_ifs_illusions",
-        "Fog Lighten (IFS Illusions)")
+    FOG_LIGHTEN_IFS_ILLUSIONS = "fog_lighten_ifs_illusions"
     GAMMA_ILLUMINATION = "gamma_illumination"
     GAMMA_LIGHT = "gamma_light"
     HARD_LIGHT = "hard_light"
@@ -100,25 +93,21 @@ class BlendingMode(EnumGroup):
     LINEAR_DODGE = "linear_dodge"
     LINEAR_LIGHT = "linear light"
     LUMINOSITY_SAI = "luminosity_sai"
-    PNORM_A = "pnorm_a", "P-Norm A"
-    PNORM_B = "pnorm_b", "P-Norm B"
+    PNORM_A = "pnorm_a"
+    PNORM_B = "pnorm_b"
     PIN_LIGHT = "pin_light"
     SCREEN = "screen"
-    SOFT_LIGHT_IFS_ILLUSIONS = (
-        "soft_light_ifs_illusions",
-        "Soft Light (IFS Illusions)")
-    SOFT_LIGHT_PEGTOP_DELPHI = (
-        "soft_light_pegtop_delphi"
-        "Soft Light (Pegtio-Delphi)")
-    SOFT_LIGHT = "soft_light", "Soft Light (Photoshop)"
-    SOFT_LIGHT_SVG = "soft_light_svg", "Soft Light (SVG)"
+    SOFT_LIGHT_IFS_ILLUSIONS = "soft_light_ifs_illusions"
+    SOFT_LIGHT_PEGTOP_DELPHI = "soft_light_pegtop_delphi"
+    SOFT_LIGHT = "soft_light"
+    SOFT_LIGHT_SVG = "soft_light_svg"
     SUPER_LIGHT = "super_light"
-    TINT_IFS_ILLUSIONS = "tint_ifs_illusions", "Tint (IFS Illusions)"
+    TINT_IFS_ILLUSIONS = "tint_ifs_illusions"
     VIVID_LIGHT = "vivid_light"
 
     _misc = Group("Misc")
     BUMPMAP = "bumpmap"
-    COMBINE_NORMAL = "combine_normal", "Combine Normal Map"
+    COMBINE_NORMAL = "combine_normal"
     COPY = "copy"
     COPY_BLUE = "copy_blue"
     COPY_GREEN = "copy_green"
@@ -138,13 +127,11 @@ class BlendingMode(EnumGroup):
     GRAIN_MERGE = "grain_merge"
     GREATER = "greater"
     HARD_MIX = "hard mix"
-    HARD_MIX_PHOTOSHOP = "hard_mix_photoshop", "Hard Mix (Photoshop)"
-    HARD_MIX_SOFTER_PHOTOSHOP = (
-        "hard_mix_softer_photoshop",
-        "Hard Mix Softer (Photoshop)")
+    HARD_MIX_PHOTOSHOP = "hard_mix_photoshop"
+    HARD_MIX_SOFTER_PHOTOSHOP = "hard_mix_softer_photoshop"
     HARD_OVERLAY = "hard overlay"
     INTERPOLATION = "interpolation"
-    INTERPOLATION_2X = "interpolation 2x", "Interpolation - 2X"
+    INTERPOLATION_2X = "interpolation 2x"
     NORMAL = "normal"
     OVERLAY = "overlay"
     PARALLEL = "parallel"
@@ -155,14 +142,10 @@ class BlendingMode(EnumGroup):
 
     _modulo = Group("Modulo")
     DIVISIVE_MODULO = "divisive_modulo"
-    DIVISIVE_MODULO_CONTINUOUS = (
-        "divisive_modulo_continuous",
-        "Divisive Modulo - Continuous")
-    MODULO_CONTINUOUS = "modulo_continuous", "Modulo - Continuous"
+    DIVISIVE_MODULO_CONTINUOUS = "divisive_modulo_continuous"
+    MODULO_CONTINUOUS = "modulo_continuous"
     MODULO_SHIFT = "modulo_shift"
-    MODULO_SHIFT_CONTINUOUS = (
-        "modulo_shift_continuous",
-        "Modulo Shift - Continuous")
+    MODULO_SHIFT_CONTINUOUS = "modulo_shift_continuous"
 
     _negative = Group("Negative")
     ADDITIVE_SUBTRACTIVE = "additive_subtractive"
@@ -174,24 +157,82 @@ class BlendingMode(EnumGroup):
 
     _quadratic = Group("Quadratic")
     FREEZE = "freeze"
-    FREEZE_REFLECT = "freeze_reflect", "Freeze-Reflect"
+    FREEZE_REFLECT = "freeze_reflect"
     GLOW = "glow"
-    GLOW_HEAT = "glow_heat", "Glow-Heat"
+    GLOW_HEAT = "glow_heat"
     HEAT = "heat"
-    HEAT_GLOW = "heat_glow", "Heat-Glow"
-    HEAT_GLOW_FREEZE_REFLECT_HYBRID = (
-        "heat_glow_freeze_reflect_hybrid"
-        "Heat-Glow & Freeze-Reflect Hybrid")
+    HEAT_GLOW = "heat_glow"
+    HEAT_GLOW_FREEZE_REFLECT_HYBRID = "heat_glow_freeze_reflect_hybrid"
     REFLECT = "reflect"
-    REFLECT_FREEZE = "reflect_freeze", "Reflect-Freeze"
-
-    def __init__(self, value: str, pretty_name: Optional[str] = None):
-        self._value_ = value
-        self._custom_pretty_name = pretty_name
+    REFLECT_FREEZE = "reflect_freeze"
 
     @property
     def pretty_name(self) -> str:
-        """Format blending mode name as in Krita Blending Mode combobox."""
-        if self._custom_pretty_name is not None:
-            return self._custom_pretty_name
-        return self.name.replace("_", " ").title()
+        """Format tool name as in Krita Blending Mode combobox."""
+        if self in PRETTY_NAMES:
+            return PRETTY_NAMES[self]
+        return self.name.replace('_', ' ').title()
+
+
+PRETTY_NAMES = {
+    BlendingMode.ADD: "Addition",
+    BlendingMode.AND: "AND",
+    BlendingMode.CONVERSE: "CONVERSE",
+    BlendingMode.IMPLICATION: "IMPLICATION",
+    BlendingMode.NAND: "NAND",
+    BlendingMode.NOR: "NOR",
+    BlendingMode.NOT_CONVERSE: "NOT_CONVERSE",
+    BlendingMode.NOT_IMPLICATION: "NOT_IMPLICATION",
+    BlendingMode.OR: "OR",
+    BlendingMode.XNOR: "XNOR",
+    BlendingMode.XOR: "XOR",
+    BlendingMode.FOG_DARKEN_IFS_ILLUSIONS: "Fog Darken (IFS Illusions)",
+    BlendingMode.SHADE_IFS_ILLUSIONS: "Shade (IFS Illusions)",
+    BlendingMode.COLOR_HSI: "Color HSI",
+    BlendingMode.DEC_INTENSITY: "Decrease Intensity",
+    BlendingMode.DEC_SATURATION_HSI: "Decrease Saturation HSI",
+    BlendingMode.HUE_HSI: "Hue HSI",
+    BlendingMode.INC_INTENSITY: "Increase Intensity",
+    BlendingMode.INC_SATURATION_HSI: "Increase Saturation HSI",
+    BlendingMode.SATURATION_HSI: "Saturation HSI",
+    BlendingMode.COLOR_HSL: "Color HSL",
+    BlendingMode.DEC_LIGHTNESS: "Decrease Lightness",
+    BlendingMode.DEC_SATURATION_HSL: "Decrease Saturation HSL",
+    BlendingMode.HUE_HSL: "Hue HSL",
+    BlendingMode.INC_LIGHTNESS: "Increase Lightness",
+    BlendingMode.INC_SATURATION_HSL: "Increase Saturation HSL",
+    BlendingMode.SATURATION_HSL: "Saturation HSL",
+    BlendingMode.COLOR_HSV: "Color HSV",
+    BlendingMode.DEC_SATURATION_HSV: "Decrease Saturation HSV",
+    BlendingMode.DEC_VALUE: "Decrease Value",
+    BlendingMode.HUE_HSV: "Hue HSV",
+    BlendingMode.INC_SATURATION_HSV: "Increase Saturation HSV",
+    BlendingMode.INC_VALUE: "Increase Value",
+    BlendingMode.SATURATION_HSV: "Saturation HSV",
+    BlendingMode.DEC_LUMINOSITY: "Decrease Luminosity",
+    BlendingMode.DEC_SATURATION: "Decrease Saturation",
+    BlendingMode.INC_LUMINOSITY: "Increase Luminosity",
+    BlendingMode.INC_SATURATION: "Increase Saturation",
+    BlendingMode.FOG_LIGHTEN_IFS_ILLUSIONS: "Fog Lighten (IFS Illusions)",
+    BlendingMode.PNORM_A: "P-Norm A",
+    BlendingMode.PNORM_B: "P-Norm B",
+    BlendingMode.SOFT_LIGHT_IFS_ILLUSIONS: "Soft Light (IFS Illusions)",
+    BlendingMode.SOFT_LIGHT_PEGTOP_DELPHI: "Soft Light (Pegtio-Delphi)",
+    BlendingMode.SOFT_LIGHT: "Soft Light (Photoshop)",
+    BlendingMode.SOFT_LIGHT_SVG: "Soft Light (SVG)",
+    BlendingMode.TINT_IFS_ILLUSIONS: "Tint (IFS Illusions)",
+    BlendingMode.COMBINE_NORMAL: "Combine Normal Map",
+    BlendingMode.HARD_MIX_PHOTOSHOP: "Hard Mix (Photoshop)",
+    BlendingMode.HARD_MIX_SOFTER_PHOTOSHOP: "Hard Mix Softer (Photoshop)",
+    BlendingMode.INTERPOLATION_2X: "Interpolation - 2X",
+    BlendingMode.DIVISIVE_MODULO_CONTINUOUS: "Divisive Modulo - Continuous",
+    BlendingMode.MODULO_CONTINUOUS: "Modulo - Continuous",
+    BlendingMode.MODULO_SHIFT_CONTINUOUS: "Modulo Shift - Continuous",
+    BlendingMode.FREEZE_REFLECT: "Freeze-Reflect",
+    BlendingMode.GLOW_HEAT: "Glow-Heat",
+    BlendingMode.HEAT_GLOW: "Heat-Glow",
+    BlendingMode.HEAT_GLOW_FREEZE_REFLECT_HYBRID:
+        "Heat-Glow & Freeze-Reflect Hybrid",
+    BlendingMode.REFLECT_FREEZE: "Reflect-Freeze",
+
+}

--- a/shortcut_composer/api_krita/enums/tool.py
+++ b/shortcut_composer/api_krita/enums/tool.py
@@ -3,7 +3,6 @@
 
 from krita import Krita as Api
 
-from typing import Optional
 from PyQt5.QtGui import QIcon
 from .helpers import EnumGroup, Group
 
@@ -11,10 +10,10 @@ from .helpers import EnumGroup, Group
 class Tool(EnumGroup):
 
     _vectors = Group("Vectors")
-    SHAPE_SELECT = "InteractionTool", "Select Shapes Tool"
+    SHAPE_SELECT = "InteractionTool"
     TEXT = "SvgTextTool"
     EDIT_SHAPES = "PathTool"
-    CALLIGRAPHY = "KarbonCalligraphyTool", "Calligraphy"
+    CALLIGRAPHY = "KarbonCalligraphyTool"
 
     _painting = Group("Painting")
     FREEHAND_BRUSH = "KritaShape/KisToolBrush"
@@ -33,16 +32,16 @@ class Tool(EnumGroup):
     MOVE = "KritaTransform/KisToolMove"
     CROP = "KisToolCrop"
     GRADIENT = "KritaFill/KisToolGradient"
-    COLOR_SAMPLER = "KritaSelected/KisToolColorSampler", "Color Sampler"
+    COLOR_SAMPLER = "KritaSelected/KisToolColorSampler"
     COLORIZE_MASK = "KritaShape/KisToolLazyBrush"
     SMART_PATCH = "KritaShape/KisToolSmartPatch"
     FILL = "KritaFill/KisToolFill"
-    ENCLOSE_AND_FILL = "KisToolEncloseAndFill", "Enclose and Fill Tool"
+    ENCLOSE_AND_FILL = "KisToolEncloseAndFill"
 
     _utility = Group("Utility")
-    ASSISTANTS = "KisAssistantTool", "Assistant Tool"
+    ASSISTANTS = "KisAssistantTool"
     MEASUREMENT = "KritaShape/KisToolMeasure"
-    REFERENCE = "ToolReferenceImages", "Reference Images Tool"
+    REFERENCE = "ToolReferenceImages"
 
     _selection = Group("Selection")
     RECTANGULAR_SELECTION = "KisToolSelectRectangular"
@@ -58,15 +57,11 @@ class Tool(EnumGroup):
     ZOOM = "ZoomTool"
     PAN = "PanTool"
 
-    def __init__(self, value: str, pretty_name: Optional[str] = None):
-        self._value_ = value
-        self._custom_pretty_name = pretty_name
-
     @property
     def pretty_name(self) -> str:
         """Format tool name as in Krita Blending Mode combobox."""
-        if self._custom_pretty_name is not None:
-            return self._custom_pretty_name
+        if self in PRETTY_NAMES:
+            return PRETTY_NAMES[self]
         return f"{self.name.replace('_', ' ').title()} Tool"
 
     def activate(self):
@@ -81,3 +76,13 @@ class Tool(EnumGroup):
     def icon(self) -> QIcon:
         """Return the icon of this tool."""
         return Api.instance().action(self.value).icon()
+
+
+PRETTY_NAMES = {
+    Tool.SHAPE_SELECT: "Select Shapes Tool",
+    Tool.CALLIGRAPHY: "Calligraphy",
+    Tool.COLOR_SAMPLER: "Color Sampler",
+    Tool.ENCLOSE_AND_FILL: "Enclose and Fill Tool",
+    Tool.ASSISTANTS: "Assistant Tool",
+    Tool.REFERENCE: "Reference Images Tool",
+}

--- a/shortcut_composer/api_krita/pyqt/custom_widgets.py
+++ b/shortcut_composer/api_krita/pyqt/custom_widgets.py
@@ -27,11 +27,6 @@ class BaseWidget(QWidget):
         """Move the widget by providing a new center point."""
         self.move(new_center-self.center)  # type: ignore
 
-    def setGeometry(self, ax: int, ay: int, aw: int, ah: int) -> None:
-        center = self.center_global
-        super().setGeometry(ax, ay, aw, ah)
-        self.move_center(center)
-
 
 class AnimatedWidget(QWidget):
     """Adds the fade-in animation when the widget is shown (60 FPS)."""

--- a/shortcut_composer/manual.html
+++ b/shortcut_composer/manual.html
@@ -9,7 +9,7 @@
 
 <body>
 
-    <h1 id="shortcut-composer-v1-4-1-">Shortcut composer <strong>v1.4.1</strong></h1>
+    <h1 id="shortcut-composer-v1-4-2-">Shortcut composer <strong>v1.4.2</strong></h1>
     <hr>
     <p><strong><code>Extension</code></strong> for painting application <strong><code>Krita</code></strong>, which allows to create custom, complex <strong><code>keyboard shortcuts</code></strong>.</p>
     <p>The plugin adds new shortcuts of the following types:</p>

--- a/shortcut_composer/templates/pie_menu.py
+++ b/shortcut_composer/templates/pie_menu.py
@@ -222,9 +222,9 @@ class PieMenu(RawInstructions, Generic[T]):
 
         if self._edit_mode:
             return
-        self.pie_manager.stop()
 
         self.actuator.activate(self.pie_widget.active)
+        self.pie_manager.stop()
 
     def _move_accept_button_to_center(self):
         """Ensure the accept button is in the center of the pie."""

--- a/shortcut_composer/templates/pie_menu.py
+++ b/shortcut_composer/templates/pie_menu.py
@@ -156,6 +156,10 @@ class PieMenu(RawInstructions, Generic[T]):
             radius_callback=lambda: self._style.accept_button_radius,
             style=self._style,
             config=self._config)
+
+        # Work around the Qt bug where button resets to (0, 0) on config change
+        self._config.register_callback(self._move_accept_button_to_center)
+
         accept_button.clicked.connect(lambda: self._edit_mode.set(False))
         accept_button.hide()
         return accept_button
@@ -170,7 +174,7 @@ class PieMenu(RawInstructions, Generic[T]):
         self._controller.refresh()
         self._reset_labels()
         self.pie_widget.label_holder.reset()  # HACK: should be automatic
-        self.accept_button.move_center(self.pie_widget.center)
+        self._move_accept_button_to_center()
         self.settings_button.move(QPoint(
             self.pie_widget.width()-self.settings_button.width(),
             self.pie_widget.height()-self.settings_button.height()))
@@ -221,3 +225,7 @@ class PieMenu(RawInstructions, Generic[T]):
         self.pie_manager.stop()
 
         self.actuator.activate(self.pie_widget.active)
+
+    def _move_accept_button_to_center(self):
+        """Ensure the accept button is in the center of the pie."""
+        self.accept_button.move_center(self.pie_widget.center)

--- a/shortcut_composer/templates/pie_menu.py
+++ b/shortcut_composer/templates/pie_menu.py
@@ -160,13 +160,6 @@ class PieMenu(RawInstructions, Generic[T]):
         accept_button.hide()
         return accept_button
 
-    def _move_buttons(self):
-        """Move accept and setting buttons to their correct positions."""
-        self.accept_button.move_center(self.pie_widget.center)
-        self.settings_button.move(QPoint(
-            self.pie_widget.width()-self.settings_button.width(),
-            self.pie_widget.height()-self.settings_button.height()))
-
     def on_key_press(self) -> None:
         """Handle the event of user pressing the action key."""
         super().on_key_press()
@@ -177,7 +170,10 @@ class PieMenu(RawInstructions, Generic[T]):
         self._controller.refresh()
         self._reset_labels()
         self.pie_widget.label_holder.reset()  # HACK: should be automatic
-        self._move_buttons()
+        self.accept_button.move_center(self.pie_widget.center)
+        self.settings_button.move(QPoint(
+            self.pie_widget.width()-self.settings_button.width(),
+            self.pie_widget.height()-self.settings_button.height()))
         self.actuator.mark_selected_widget(self.pie_widget.widget_holder)
 
         self.pie_manager.start()

--- a/shortcut_composer/templates/pie_menu_utils/edit_mode.py
+++ b/shortcut_composer/templates/pie_menu_utils/edit_mode.py
@@ -46,6 +46,7 @@ class EditMode:
         self._move_settings_next_to_pie()
         self._obj.accept_button.show()
         self._obj.settings_button.hide()
+        self._obj.pie_widget.active = None
 
     def _move_settings_next_to_pie(self):
         """Move settings window so that it lies on right side of pie."""

--- a/shortcut_composer/templates/pie_menu_utils/edit_mode.py
+++ b/shortcut_composer/templates/pie_menu_utils/edit_mode.py
@@ -45,6 +45,7 @@ class EditMode:
         self._obj.pie_settings.resize(self._obj.pie_settings.sizeHint())
         self._move_settings_next_to_pie()
         self._obj.accept_button.show()
+        self._obj.accept_button.move_center(self._obj.pie_widget.center)
         self._obj.settings_button.hide()
 
     def _move_settings_next_to_pie(self):

--- a/shortcut_composer/templates/pie_menu_utils/edit_mode.py
+++ b/shortcut_composer/templates/pie_menu_utils/edit_mode.py
@@ -45,7 +45,6 @@ class EditMode:
         self._obj.pie_settings.resize(self._obj.pie_settings.sizeHint())
         self._move_settings_next_to_pie()
         self._obj.accept_button.show()
-        self._obj.accept_button.move_center(self._obj.pie_widget.center)
         self._obj.settings_button.hide()
 
     def _move_settings_next_to_pie(self):

--- a/shortcut_composer/templates/pie_menu_utils/pie_manager.py
+++ b/shortcut_composer/templates/pie_menu_utils/pie_manager.py
@@ -38,6 +38,7 @@ class PieManager:
 
     def stop(self, hide: bool = True) -> None:
         """Hide the widget and stop the mouse tracking loop."""
+        self._pie_widget.active = None
         self._timer.stop()
         for label in self._pie_widget.label_holder:
             label.activation_progress.reset()
@@ -50,6 +51,9 @@ class PieManager:
         # released during the drag&drop operation or when user clicked
         # outside the pie widget.
         if not self._pie_widget.isVisible():
+            return self.stop()
+
+        if self._pie_widget.edit_mode.get():
             return self.stop()
 
         cursor = QCursor().pos()

--- a/shortcut_composer/templates/pie_menu_utils/pie_widget.py
+++ b/shortcut_composer/templates/pie_menu_utils/pie_widget.py
@@ -63,7 +63,7 @@ class PieWidget(AnimatedWidget, BaseWidget, Generic[T]):
 
         self._style = style
         self._labels = labels
-        self._edit_mode = edit_mode
+        self.edit_mode = edit_mode
         self.config = config
 
         self.config.PIE_RADIUS_SCALE.register_callback(self._reset)
@@ -99,7 +99,7 @@ class PieWidget(AnimatedWidget, BaseWidget, Generic[T]):
 
     def dragEnterEvent(self, e: QDragEnterEvent) -> None:
         """Allow dragging the widgets while in edit mode."""
-        if self._edit_mode:
+        if self.edit_mode:
             return e.accept()
         e.ignore()
 

--- a/shortcut_composer/templates/pie_menu_utils/pie_widget.py
+++ b/shortcut_composer/templates/pie_menu_utils/pie_widget.py
@@ -65,7 +65,11 @@ class PieWidget(AnimatedWidget, BaseWidget, Generic[T]):
         self._labels = labels
         self._edit_mode = edit_mode
         self.config = config
-        self.config.register_callback(self._reset)
+
+        self.config.PIE_RADIUS_SCALE.register_callback(self._reset)
+        self.config.ICON_RADIUS_SCALE.register_callback(self._reset)
+        Config.PIE_GLOBAL_SCALE.register_callback(self._reset)
+        Config.PIE_ICON_GLOBAL_SCALE.register_callback(self._reset)
 
         self.active: Optional[Label] = None
         self._last_widget = None
@@ -77,7 +81,6 @@ class PieWidget(AnimatedWidget, BaseWidget, Generic[T]):
             owner=self)
 
         self.set_draggable(False)
-        self._reset()
 
     def _reset(self):
         """Set widget geometry according to style and refresh CirclePoints."""


### PR DESCRIPTION
## What's new in **1.4.2**

This release fixes actions broken with krita 5.2.0 introducing Python 3.10 - some tools and blending modes made the plugin silently crash. It also addresses a few other issues that were always present.

### Fixed

- **Fix implementation of BlendingMode and Tool enums which caused crash for certain values in krita 5.2.0 and later**
- Fix the pie menu occasionally floating away after reordering labels
- Fix the pie menu floating away after reordering labels on multi-screen setup with Windows10 UI scaling enabled
- Fix the pie occasionally displaying the active label or its artifacts when entering edit mode