### PR TITLE
Deploy 1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Shortcut composer **v1.5.0**
+# Shortcut composer **v1.5.1**
 
 [![python](https://img.shields.io/badge/Python-3.10-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
 [![Code style: black](https://img.shields.io/badge/code%20style-autopep8-333333.svg)](https://pypi.org/project/autopep8/)

--- a/shortcut_composer/INFO.py
+++ b/shortcut_composer/INFO.py
@@ -5,7 +5,7 @@
 
 from api_krita.wrappers import Version
 
-__version__ = Version(1, 5, 0)
+__version__ = Version(1, 5, 1, "dev")
 """Version of the Shortcut Composer plugin."""
 
 __required_krita_version__ = Version(5, 2, 2)

--- a/shortcut_composer/INFO.py
+++ b/shortcut_composer/INFO.py
@@ -5,7 +5,7 @@
 
 from api_krita.wrappers import Version
 
-__version__ = Version(1, 5, 1, "dev")
+__version__ = Version(1, 5, 1)
 """Version of the Shortcut Composer plugin."""
 
 __required_krita_version__ = Version(5, 2, 2)

--- a/shortcut_composer/api_krita/__init__.py
+++ b/shortcut_composer/api_krita/__init__.py
@@ -12,10 +12,9 @@ Other api elements that require importing from other packages are
 available here so that the imports to omit unresolved warnings there.
 """
 
-from krita import Extension
 from .core_api import KritaInstance
 
 Krita = KritaInstance()
 """Wraps krita API for typing, documentation and PEP8 compatibility."""
 
-__all__ = ["Extension", "Krita"]
+__all__ = ["Krita"]

--- a/shortcut_composer/api_krita/core_api.py
+++ b/shortcut_composer/api_krita/core_api.py
@@ -13,6 +13,7 @@ from PyQt5.QtGui import QKeySequence, QColor, QIcon, QPalette
 from PyQt5.QtCore import QTimer
 
 from .wrappers import (
+    UnknownVersion,
     ToolDescriptor,
     Document,
     Version,
@@ -146,16 +147,18 @@ class KritaInstance:
     @property
     def version(self) -> Version:
         """Get version of krita."""
-        raw_string: str = self.instance.version()
-        version, *additional_info = raw_string.split("-")
+        try:
+            raw_string: str = self.instance.version()
+            version, *additional_info = raw_string.split("-")
 
-        major, minor, fix = version.split(".")
+            major, minor, fix = version.split(".")
 
-        version = Version(int(major), int(minor), int(fix))
-        if additional_info:
-            version.additional_info = additional_info[0]
-
-        return version
+            version = Version(int(major), int(minor), int(fix))
+            if additional_info:
+                version.additional_info = additional_info[0]
+            return version
+        except Exception:
+            return UnknownVersion()
 
 
 class KritaWindow(Protocol):

--- a/shortcut_composer/api_krita/wrappers/__init__.py
+++ b/shortcut_composer/api_krita/wrappers/__init__.py
@@ -7,16 +7,17 @@ Wrappers of classes in krita API.
 Adds typing, docstrings and changes the interface to be PEP8 compatible.
 """
 
+from .version import Version, UnknownVersion
 from .tool_descriptor import ToolDescriptor
 from .database import Database
 from .document import Document
-from .version import Version
 from .canvas import Canvas
 from .cursor import Cursor
 from .node import Node
 from .view import View
 
 __all__ = [
+    "UnknownVersion",
     "ToolDescriptor",
     "Database",
     "Document",

--- a/shortcut_composer/api_krita/wrappers/version.py
+++ b/shortcut_composer/api_krita/wrappers/version.py
@@ -18,6 +18,9 @@ class Version:
     additional_info: str = ""
 
     def __lt__(self, other: 'Version') -> bool:
+        if isinstance(other, UnknownVersion):
+            return True
+
         def version_as_int(version: Version) -> int:
             return version.major*1_000_000 + version.minor*1_000 + version.fix
 
@@ -27,3 +30,17 @@ class Version:
         if not self.additional_info:
             return f"{self.major}.{self.minor}.{self.fix}"
         return f"{self.major}.{self.minor}.{self.fix}-{self.additional_info}"
+
+
+class UnknownVersion(Version):
+    """Represents unknown application version."""
+
+    def __init__(self) -> None:
+        super().__init__(0, 0, 0, "unknown")
+
+    def __lt__(self, other: 'Version') -> bool:
+        """Consider unknown version to be higher than any valid one."""
+        return False
+
+    def __str__(self) -> str:
+        return "unknown"

--- a/shortcut_composer/api_krita/wrappers/view.py
+++ b/shortcut_composer/api_krita/wrappers/view.py
@@ -1,10 +1,11 @@
 # SPDX-FileCopyrightText: © 2022-2024 Wojciech Trybus <wojtryb@gmail.com>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from krita import Krita as Api
 from dataclasses import dataclass
 from typing import Protocol
 from functools import cached_property
+
+from krita import Krita as Api
 
 from ..enums import BlendingMode
 

--- a/shortcut_composer/manual.html
+++ b/shortcut_composer/manual.html
@@ -9,7 +9,7 @@
 
 <body>
 
-    <h1 id="shortcut-composer-v1-5-0-">Shortcut composer <strong>v1.5.0</strong></h1>
+    <h1 id="shortcut-composer-v1-5-1-">Shortcut composer <strong>v1.5.1</strong></h1>
     <hr>
     <p><strong><code>Extension</code></strong> for painting application <strong><code>Krita</code></strong>, which allows to create custom, complex <strong><code>keyboard shortcuts</code></strong>.</p>
     <p>The plugin adds new shortcuts of the following types:</p>

--- a/shortcut_composer/shortcut_composer.py
+++ b/shortcut_composer/shortcut_composer.py
@@ -4,7 +4,8 @@
 from dataclasses import dataclass
 from PyQt5.QtWidgets import QWidgetAction
 
-from api_krita import Krita, Extension  # type: ignore
+from krita import Extension
+from api_krita import Krita
 from api_krita.actions import TransformModeActions
 from actions import create_actions
 from composer_utils import SettingsDialog

--- a/shortcut_composer/templates/pie_menu_utils/pie_config_impl/preset_pie_config.py
+++ b/shortcut_composer/templates/pie_menu_utils/pie_config_impl/preset_pie_config.py
@@ -79,7 +79,7 @@ class PresetPieConfig(PieConfig[str]):
         self.TAG_NAME.field.refresh()
         self.ORDER.write(self.values())
 
-    def set_current_as_default(self):
+    def set_current_as_default(self) -> None:
         """Set current pie values as a new default list of values."""
         self.TAG_MODE.default = self.TAG_MODE.read()
         self.TAG_NAME.default = self.TAG_NAME.read()

--- a/shortcut_composer/templates/pie_menu_utils/pie_manager.py
+++ b/shortcut_composer/templates/pie_menu_utils/pie_manager.py
@@ -52,6 +52,9 @@ class PieManager:
         if self._pie_widget.is_in_edit_mode:
             return self.stop()
 
+        if not self._pie_widget.order_handler:
+            return
+
         cursor = QCursor().pos()
         circle = CirclePoints(self._pie_widget.center_global, 0)
         if circle.distance(cursor) < self._pie_widget.deadzone:

--- a/shortcut_composer/templates/pie_menu_utils/pie_style.py
+++ b/shortcut_composer/templates/pie_menu_utils/pie_style.py
@@ -23,6 +23,7 @@ class PieStyle:
         deadzone_radius_callback: Callable[[], float],
         settings_button_radius_callback: Callable[[], int],
         accept_button_radius_callback: Callable[[], int],
+        background_opacity_callback: Callable[[], int],
     ) -> None:
         self._unscaled_label_style = unscaled_label_style
 
@@ -30,6 +31,7 @@ class PieStyle:
         self._deadzone_radius_callback = deadzone_radius_callback
         self._settings_button_radius_callback = settings_button_radius_callback
         self._accept_button_radius_callback = accept_button_radius_callback
+        self._background_opacity_callback = background_opacity_callback
 
     @property
     def pie_radius(self) -> int:
@@ -84,7 +86,12 @@ class PieStyle:
     @property
     def background_color(self) -> QColor:
         """Color of the widget background."""
-        return self._unscaled_label_style.background_color
+        opaque = self._unscaled_label_style.background_color
+        return QColor(
+            opaque.red(),
+            opaque.green(),
+            opaque.blue(),
+            round(self._background_opacity_callback() * 255/100))
 
     @property
     def active_color_dark(self) -> QColor:
@@ -99,7 +106,7 @@ class PieStyle:
     @property
     def background_decorator_color(self) -> QColor:
         """Color of decorator near inner edge."""
-        color = self.background_color
+        color = self._unscaled_label_style.background_color
         color = QColor(color.red()-5, color.green()-5, color.blue()-5, 60)
         return color
 

--- a/shortcut_composer/templates/pie_menu_utils/pie_style_holder.py
+++ b/shortcut_composer/templates/pie_menu_utils/pie_style_holder.py
@@ -34,7 +34,8 @@ class PieStyleHolder:
             pie_radius_callback=self._pie_radius,
             deadzone_radius_callback=self._deadzone_radius,
             settings_button_radius_callback=self._settings_button_radius,
-            accept_button_radius_callback=self._accept_button_radius)
+            accept_button_radius_callback=self._accept_button_radius,
+            background_opacity_callback=self._pie_config.PIE_OPACITY.read)
 
     def _pie_radius(self) -> int:
         """Return pie radius based on configured value."""

--- a/shortcut_composer/templates/pie_menu_utils/pie_widget_utils/order_handler.py
+++ b/shortcut_composer/templates/pie_menu_utils/pie_widget_utils/order_handler.py
@@ -93,6 +93,10 @@ class OrderHandler:
         """Iterate over all labels in the holder."""
         return iter(self._labels)
 
+    def __bool__(self) -> bool:
+        """Return whether the label list is empty."""
+        return bool(self._labels)
+
     def reset(self, notify: bool = True) -> None:
         """
         Ensure the icon widgets properly represents this container.

--- a/shortcut_composer/templates/rotation_menu_utils/rotation_settings.py
+++ b/shortcut_composer/templates/rotation_menu_utils/rotation_settings.py
@@ -82,8 +82,8 @@ class RotationSettings(BaseWidget):
                 parent=self,
                 pretty_name="Outline opacity",
                 step=1,
-                max_value=255,
-                tooltip="Opacity of the widget outline."),
+                max_value=100,
+                tooltip="Opacity [%] of the widget outline."),
 
             "Values",
             Checkbox(

--- a/shortcut_composer/templates/rotation_menu_utils/rotation_style.py
+++ b/shortcut_composer/templates/rotation_menu_utils/rotation_style.py
@@ -107,4 +107,5 @@ class RotationStyle:
     @property
     def outline_opacity(self) -> int:
         """Opacity [0-255] of the outline for deadzone, and inner zone."""
-        return round(self._outline_opacity_callback() * 255/100)
+        opacity = round(self._outline_opacity_callback() * 255/100)
+        return sorted([0, opacity, 255])[1]

--- a/shortcut_composer/templates/rotation_menu_utils/rotation_style.py
+++ b/shortcut_composer/templates/rotation_menu_utils/rotation_style.py
@@ -106,5 +106,5 @@ class RotationStyle:
 
     @property
     def outline_opacity(self) -> int:
-        """Opacity of the two color outline for deadzone, and inner zone."""
-        return self._outline_opacity_callback()
+        """Opacity [0-255] of the outline for deadzone, and inner zone."""
+        return round(self._outline_opacity_callback() * 255/100)

--- a/shortcut_composer/templates/rotation_menu_utils/rotation_widget_utils/rotation_painter.py
+++ b/shortcut_composer/templates/rotation_menu_utils/rotation_widget_utils/rotation_painter.py
@@ -121,7 +121,7 @@ class RotationPainter:
             span=span,
             color=self._scale_opacity(
                 self._style.active_color, animation_value),
-            thickness=thickness+thickness_change)
+            thickness=thickness+thickness_change+2)
 
         # indicator decorator
         self._painter.paint_pie(

--- a/shortcut_composer/templates/rotation_selector.py
+++ b/shortcut_composer/templates/rotation_selector.py
@@ -43,9 +43,12 @@ class RotationSelector(RawInstructions):
     - `offset`              -- (optional) default offset of zero value
     - `inverse_zones`       -- (optional) default order of zones
     - `divisions` -- (optional) default amount of values in intervallic zone
+    - `active_color`      -- (optional) default rgba color of active pie
     - `deadzone strategy` -- (optional) default strategy what to do,
                               when mouse does not leave deadzone
-    - `active_color`      -- (optional) default rgba color of active pie
+    - `outline_opacity`   -- (optional) opacity in %
+    - `short_vs_long_press_time` -- (optional) time [s] that specifies
+                                    if key press is short or long.
 
     ### Action implementation example:
 
@@ -78,7 +81,7 @@ class RotationSelector(RawInstructions):
         divisions: int = 24,
         active_color: QColor | None = None,
         deadzone_strategy=RotationDeadzoneStrategy.KEEP_CHANGE,
-        outline_opacity: int = 200,
+        outline_opacity: int = 75,
         short_vs_long_press_time: float | None = None,
     ) -> None:
         super().__init__(name, instructions, short_vs_long_press_time)


### PR DESCRIPTION
## What's new in **1.5.1**

### Fixed

- Prevent the occasional crash while picking label from Pie ([empty label list issue](https://github.com/wojtryb/Shortcut-Composer/issues/79))
- Fixed Pie opacity being always 100% after changing to custom color (introduced in 1.5.0)
- Fixed a crash while trying to detect a version of krita built from source

### Modified

- Changed RotationSelector outline opacity range from <0-255> to <0-100>, unifying it with Pie background
- RotationSelector indicator now overlaps the deadzone outline

> **Note**
> 
> Due to changes in RotationSelector opacity range, previously selected **outline opacity** in `Rotate brush` and `Rotate canvas` will require manual change. If the default value was never changed, the new one will work out of the box.
>
> Sorry for inconvenience.