### PR TITLE
Deploy 1.5.2

### DIFF
--- a/shortcut_composer/INFO.py
+++ b/shortcut_composer/INFO.py
@@ -5,7 +5,7 @@
 
 from api_krita.wrappers import Version
 
-__version__ = Version(1, 5, 2, "dev")
+__version__ = Version(1, 5, 2)
 """Version of the Shortcut Composer plugin."""
 
 __required_krita_version__ = Version(5, 2, 2)

--- a/shortcut_composer/INFO.py
+++ b/shortcut_composer/INFO.py
@@ -5,7 +5,7 @@
 
 from api_krita.wrappers import Version
 
-__version__ = Version(1, 5, 1)
+__version__ = Version(1, 5, 2, "dev")
 """Version of the Shortcut Composer plugin."""
 
 __required_krita_version__ = Version(5, 2, 2)

--- a/shortcut_composer/actions.py
+++ b/shortcut_composer/actions.py
@@ -344,6 +344,7 @@ def create_actions() -> list[templates.RawInstructions]: return [
     templates.RotationSelector(
         name="Rotate canvas",
         controller=controllers.CanvasRotationController(),
+        is_widget_hidden=False,
         is_counterclockwise=False,
         offset=0,
         inverse_zones=False,
@@ -355,6 +356,7 @@ def create_actions() -> list[templates.RawInstructions]: return [
     templates.RotationSelector(
         name="Rotate brush",
         controller=controllers.BrushRotationController(),
+        is_widget_hidden=False,
         is_counterclockwise=True,
         offset=90,
         inverse_zones=False,

--- a/shortcut_composer/api_krita/enums/blending_mode.py
+++ b/shortcut_composer/api_krita/enums/blending_mode.py
@@ -132,6 +132,8 @@ class BlendingMode(EnumGroup):
     HARD_OVERLAY = "hard overlay"
     INTERPOLATION = "interpolation"
     INTERPOLATION_2X = "interpolation 2x"
+    LAMBERT_lIGHTING_GAMMA_2_2 = "lambert_lighting_gamma2.2"
+    LAMBERT_lIGHTING_GAMMA_LINEAR = "lambert_lighting"
     NORMAL = "normal"
     OVERLAY = "overlay"
     PARALLEL = "parallel"
@@ -225,6 +227,8 @@ PRETTY_NAMES = {
     BlendingMode.HARD_MIX_PHOTOSHOP: "Hard Mix (Photoshop)",
     BlendingMode.HARD_MIX_SOFTER_PHOTOSHOP: "Hard Mix Softer (Photoshop)",
     BlendingMode.INTERPOLATION_2X: "Interpolation - 2X",
+    BlendingMode.LAMBERT_lIGHTING_GAMMA_2_2: "Lambert Lighting (Gamma 2.2)",
+    BlendingMode.LAMBERT_lIGHTING_GAMMA_LINEAR: "Lambert Lighting (Linear)",
     BlendingMode.DIVISIVE_MODULO_CONTINUOUS: "Divisive Modulo - Continuous",
     BlendingMode.MODULO_CONTINUOUS: "Modulo - Continuous",
     BlendingMode.MODULO_SHIFT_CONTINUOUS: "Modulo Shift - Continuous",

--- a/shortcut_composer/api_krita/wrappers/version.py
+++ b/shortcut_composer/api_krita/wrappers/version.py
@@ -29,7 +29,7 @@ class Version:
     def __str__(self) -> str:
         if not self.additional_info:
             return f"{self.major}.{self.minor}.{self.fix}"
-        return f"{self.major}.{self.minor}.{self.fix}-{self.additional_info}"
+        return f"{self.major}.{self.minor}.{self.fix} {self.additional_info}"
 
 
 class UnknownVersion(Version):

--- a/shortcut_composer/manual.html
+++ b/shortcut_composer/manual.html
@@ -9,7 +9,7 @@
 
 <body>
 
-    <h1 id="shortcut-composer-v1-5-1-">Shortcut composer <strong>v1.5.1</strong></h1>
+    <h1 id="shortcut-composer-v1-5-2-">Shortcut composer <strong>v1.5.2</strong></h1>
     <hr>
     <p><strong><code>Extension</code></strong> for painting application <strong><code>Krita</code></strong>, which allows to create custom, complex <strong><code>keyboard shortcuts</code></strong>.</p>
     <p>The plugin adds new shortcuts of the following types:</p>

--- a/shortcut_composer/templates/rotation_menu_utils/rotation_config.py
+++ b/shortcut_composer/templates/rotation_menu_utils/rotation_config.py
@@ -19,6 +19,7 @@ class RotationConfig(FieldGroup, Generic[T]):
     def __init__(
         self,
         name: str,
+        is_widget_hidden: bool,
         deadzone_strategy: RotationDeadzoneStrategy,
         inverse_zones: bool,
         divisions: int,
@@ -30,6 +31,10 @@ class RotationConfig(FieldGroup, Generic[T]):
         offset: int,
     ) -> None:
         super().__init__(name)
+
+        self.IS_WIDGET_HIDDEN = self.field(
+            name="Is widget hidden",
+            default=is_widget_hidden)
 
         self.DEADZONE_STRATEGY = self.field(
             name="Deadzone strategy",

--- a/shortcut_composer/templates/rotation_menu_utils/rotation_manager.py
+++ b/shortcut_composer/templates/rotation_menu_utils/rotation_manager.py
@@ -33,8 +33,9 @@ class RotationManager:
 
     def start(self) -> None:
         """Show widget under the mouse and start the mouse tracking loop."""
-        self._rotation_widget.move_center(QCursor().pos())
-        self._rotation_widget.show()
+        if not self._config.IS_WIDGET_HIDDEN.read():
+            self._rotation_widget.move_center(QCursor().pos())
+            self._rotation_widget.show()
 
         self._center_global = QCursor().pos()
         self._rotation_widget.state.reset()
@@ -49,9 +50,6 @@ class RotationManager:
 
     def _handle_cursor(self) -> None:
         """Calculate zone and angle of the cursor."""
-        if not self._rotation_widget.isVisible():
-            return self.stop()
-
         cursor = QCursor().pos()
         circle = CirclePoints(self._center_global, 0)
 

--- a/shortcut_composer/templates/rotation_menu_utils/rotation_settings.py
+++ b/shortcut_composer/templates/rotation_menu_utils/rotation_settings.py
@@ -31,6 +31,15 @@ class RotationSettings(BaseWidget):
         self._config = config
 
         self._general_tab = ConfigFormWidget([
+            Checkbox(
+                config_field=config.IS_WIDGET_HIDDEN,
+                parent=self,
+                pretty_name="Hide widget",
+                tooltip=""
+                "Hide the rotation widget entirely.\n\n"
+                "Option for those who prefer to preview the value directly\n"
+                "in krita. It works best with small deadzone scale and\n"
+                "inner zone scale set to zero."),
             "Behavior",
             EnumComboBox(
                 config_field=config.DEADZONE_STRATEGY,


### PR DESCRIPTION
## What's new in **1.5.2**

### Added

- Possibility to hide the selector widget with "Hide widget" in its settings 
- Support for two missing blending modes: `Lambert Lighting (Linear)` and `Lambert Lighting (Gamma 2.2)`

### Modified

- All formats of krita version are now properly supported, when detecting the version on startup
